### PR TITLE
Fix frame count issue with luminance extraction

### DIFF
--- a/process.py
+++ b/process.py
@@ -26,13 +26,6 @@ def extract_features(name, ftir_path, tracking_path, dest_path):
     # ----calculate paw luminance, average paw luminance ratio, and paw luminance log-ratio----
     # read ftir video
     ftir_video = cv2.VideoCapture(ftir_path)
-    fps = int(ftir_video.get(cv2.CAP_PROP_FPS))
-    frame_count = int(ftir_video.get(cv2.CAP_PROP_FRAME_COUNT))
-    recording_time = frame_count / fps
-
-    features["recording_time"] = np.array(recording_time)
-    features["fps"] = np.array(fps)
-    features["frame_count"] = np.array(frame_count)
     # calculate paw luminance
     (
         hind_left,
@@ -40,7 +33,15 @@ def extract_features(name, ftir_path, tracking_path, dest_path):
         front_left,
         front_right,
         background_luminance,
+        frame_count
     ) = cal_paw_luminance(label, ftir_video, size=22)
+
+    fps = int(ftir_video.get(cv2.CAP_PROP_FPS))
+    recording_time = frame_count / fps
+
+    features["recording_time"] = np.array(recording_time)
+    features["fps"] = np.array(fps)
+    features["frame_count"] = np.array(frame_count)
 
     features["hind_left_luminance"] = hind_left
     features["hind_right_luminance"] = hind_right

--- a/utils.py
+++ b/utils.py
@@ -135,6 +135,7 @@ def cal_paw_luminance(label, cap, size=22):
     # loop infinitely because we cannot trust `CAP_PROP_FRAME_COUNT`
     # https://stackoverflow.com/questions/31472155/python-opencv-cv2-cv-cv-cap-prop-frame-count-get-wrong-numbers
     # for i in tqdm(range(500)):
+    i = 0
     while True:
         ret, frame = cap.read()  # Read the next frame
 
@@ -170,6 +171,8 @@ def cal_paw_luminance(label, cap, size=22):
 
         # calculate background luminance
         background_luminance.append(np.nanmean(frame))
+
+        i += 1
 
     hind_right = np.array(hind_right)
     hind_left = np.array(hind_left)

--- a/utils.py
+++ b/utils.py
@@ -132,9 +132,15 @@ def cal_paw_luminance(label, cap, size=22):
     front_left = []
     background_luminance = []
 
+    # loop infinitely because we cannot trust `CAP_PROP_FRAME_COUNT`
+    # https://stackoverflow.com/questions/31472155/python-opencv-cv2-cv-cv-cap-prop-frame-count-get-wrong-numbers
     # for i in tqdm(range(500)):
-    for i in tqdm(range(num_of_frames)):
-        frame = cap.read()[1]  # Read the next frame
+    while True:
+        ret, frame = cap.read()  # Read the next frame
+
+        if not ret:
+            break
+
         frame = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)  # Convert to grayscale
 
         # calculate the luminance of the four paws

--- a/utils.py
+++ b/utils.py
@@ -107,7 +107,6 @@ def denoise(luminance, noise):
     luminance[luminance < 0] = 0.0
     return luminance
 
-
 def cal_paw_luminance(label, cap, size=22):
     """
     helper function for extracting the paw luminance signals of both hind paws from the ftir video
@@ -194,7 +193,7 @@ def cal_paw_luminance(label, cap, size=22):
     front_left = denoise(front_left, background_luminance)
     front_right = denoise(front_right, background_luminance)
 
-    return hind_left, hind_right, front_left, front_right, background_luminance
+    return hind_left, hind_right, front_left, front_right, background_luminance, i
 
 
 def scale_ftir(hind_left, hind_right):


### PR DESCRIPTION
The OpenCV video property `CAP_PROP_FRAME_COUNT` is [not designed to be accurate](https://stackoverflow.com/a/47796468), and relying on it causes the luminance extraction code to fail in some cases.

This fix relies on the first tuple place in the `VideoCapture.read()` function to know when we've reached the end of the video. This change places a precondition on the luminance extraction function:
`ftir_length == trans_length`

Attempting to run this function without meeting the precondition will invoke undefined behavior.