### PR TITLE
Add API for skeleton video generation

### DIFF
--- a/dlc_runner.py
+++ b/dlc_runner.py
@@ -37,13 +37,24 @@ def get_recording_list(directorys):
 #
 # THIS IS AN API ENTRYPOINT! If the signature is modified, ensure api.py matches!
 # The body of this function can change without affecting the API.
-def run_deeplabcut(dlc_config_path, body_videos):
+def run_deeplabcut(dlc_config_path, body_videos, also_generate_skeleton=True):
     deeplabcut.analyze_videos(dlc_config_path, body_videos, videotype=".avi")
     for video in body_videos:
         deeplabcut.filterpredictions(dlc_config_path, [video], save_as_csv=False)
         # deeplabcut.create_labeled_video(
         #     dlc_config_path, [video], videotype=".avi", filtered=True
         # )
+
+    if also_generate_skeleton:
+        generate_skeleton(dlc_config_path, body_videos)
+    
+    return
+
+# Function to generate a skeleton video from the specified videos
+#
+# THIS IS AN API ENTRYPOINT! If the signature is modified, ensure api.py matches!
+# The body of this function can change without affecting the API.
+def generate_skeleton(dlc_config_path, body_videos):
     deeplabcut.create_labeled_video(
         dlc_config_path,
         body_videos,
@@ -52,7 +63,6 @@ def run_deeplabcut(dlc_config_path, body_videos):
         draw_skeleton=True,
     )
     return
-
 
 # Function to prompt the user to select folders using a GUI dialog
 def select_folders():

--- a/summary.py
+++ b/summary.py
@@ -2,24 +2,6 @@ from typing import Dict, Any, List
 
 from utils import *
 
-def generate_summary_v1(features_folder: str, summary_dest: str):
-    """
-    v1 API expects all features to be in a single folder. this function collects all .h5 files in the given folder and uses them
-    """
-    features_files = []
-
-    for file in os.listdir(features_folder):
-        if file.endswith(".h5"):
-            features_files.append(os.path.join(features_folder, file))
-
-    generate_summary_generic(features_files, summary_dest)
-
-def generate_summary_v2(features_files: List[str], summary_dest: str):
-    """
-    v2 API expects a list of .h5 files. this function uses them directly
-    """
-    generate_summary_generic(features_files, summary_dest)
-
 def generate_summary_generic(features_files: List[str], summary_dest: str):
     features = defaultdict(dict)
 


### PR DESCRIPTION
Add a new API for generating skeleton videos. This was previously done unconditionally when running deeplabcut.

This functionality has been split into two API functions. The built-in analysis code will still generate the skeleton as expected, but the API will not generate the skeleton when the `deeplabcut` function is run, and instead requires an additional API call (`skeleton`). This was done to maintain backwards compatibility.